### PR TITLE
Install package dependencies on image startup.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 set -e
 
-if [ "$1" == "update" ] || ! stat /srv/node_modules/
+# if building the site or if node_modules does not exist
+if [ "$1" == "build" ] || ! stat /srv/node_modules/
 then
 
-# remove node modules to prevent node-sass platform confilcts
-rm -rf ./node_modules/
+    # remove node modules to prevent node-sass platform confilcts
+    rm -rf ./node_modules/
 
-# installing node modules to make this image work in build servers
-npm install
+    # installing node modules to make this image work in build servers
+    npm install
 
 fi
 
+# if gatsby is not installed mention this.
 if [ "$1" != "new" ] && ! grep -q "gatsby build" /srv/package.json
 then
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 set -e
 
+if [ "$1" == "update" ] || ! stat /srv/node_modules/
+then
+
 # remove node modules to prevent node-sass platform confilcts
 rm -rf ./node_modules/
 
 # installing node modules to make this image work in build servers
-npm install 
+npm install
+
+fi
 
 if [ "$1" != "new" ] && ! grep -q "gatsby build" /srv/package.json
 then
+
     echo "Run 'new yoursitename'"
     exit 1
+
 fi
 
 exec gatsby "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# remove node modules to prevent node-sass platform confilcts
+rm -rf ./node_modules/
+
+# installing node modules to make this image work in build servers
+npm install 
 
 if [ "$1" != "new" ] && ! grep -q "gatsby build" /srv/package.json
 then


### PR DESCRIPTION
If this step is not done, you must localy run npm install. This
would limit image usage on build servers and prevent this image
working on MacOS since node-sass module would install MacOS
dependencies and try to run them in Linux container.