### PR TITLE
Replace stat statement to suppress excess output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # if building the site or if node_modules does not exist
-if [ "$1" == "build" ] || ! stat /srv/node_modules/
+if [ "$1" == "build" ] || [ ! -e /srv/node_modules/ ]
 then
 
     # remove node modules to prevent node-sass platform confilcts


### PR DESCRIPTION
Prevent `stat` used in an if-check from outputting text to stdout, by replacing it with a bash [ -e filename ] type test.

(The author of this file should probably add some text or code explaining why the two locations /srv/node_modules and ./node_modules below, are not the same.)